### PR TITLE
feat(plugins): ✨ inject env into --kurv-cfg and support sidecar config discovery

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -25,7 +25,9 @@ The project uses [Taskfile](https://taskfile.dev) (`task ...`). Core workflows:
 - `task release` — runs `python scripts/release.py` (see [Release flow](#release-flow))
 - `task local-ci-release` / `task local-ci-pub` — run CI workflows locally via [nektosact](https://nektosact.com)
 
-**Tests:** plain cargo. Single test: `cargo test -p kurv --test unit_tests <filter>`. Integration test entry [app/kurv/tests/unit_tests.rs](app/kurv/tests/unit_tests.rs) → [app/kurv/tests/unit/](app/kurv/tests/unit/). [app/kurv/tests/integration/](app/kurv/tests/integration/) exists but is empty.
+**Tests:** plain cargo. Single test: `cargo test -p kurv --test unit_tests <filter>`. 
+
+Note: Do not add inline `#[cfg(test)]` modules in source files; keep tests in crate-local `tests/` folders so business logic files stay focused.
 
 **Running the server manually:** set `KURV_SERVER=true` or pass `--force`, otherwise the binary refuses to start as a server (safety measure — same binary is also the client).
 

--- a/.agents/skills/create-github-issues/SKILL.md
+++ b/.agents/skills/create-github-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-github-issues
-description: 'Create GitHub issues following repository conventions. Use when drafting, planning, or creating issues, or sub-issues.'
+description: 'Create GitHub issues. Use when you need to create issues. DO NOT USE when working on issue implementation.'
 argument-hint: 'What issue should be created or drafted?'
 user-invocable: true
 disable-model-invocation: false

--- a/app/kurv/src/kurv/plugins/mod.rs
+++ b/app/kurv/src/kurv/plugins/mod.rs
@@ -3,10 +3,29 @@ use {
     anyhow::{Context, Result, anyhow},
     log::{debug, info, warn},
     std::{
+        collections::HashMap,
         path::{Path, PathBuf},
         process::Command,
     },
 };
+
+fn injected_plugin_env(info: &Info) -> HashMap<String, String> {
+    HashMap::from([
+        ("KURV_API_HOST".to_string(), info.api_host.clone()),
+        ("KURV_API_PORT".to_string(), info.api_port.to_string()),
+        ("KURV_HOME".to_string(), info.paths.kurv_home.display().to_string()),
+        ("KURV_LOGS_DIR".to_string(), info.paths.logs_dir.display().to_string()),
+    ])
+}
+
+fn merge_injected_plugin_env(
+    existing_env: Option<HashMap<String, String>>,
+    info: &Info,
+) -> HashMap<String, String> {
+    let mut env = existing_env.unwrap_or_default();
+    env.extend(injected_plugin_env(info));
+    env
+}
 
 /// discovers all plugins in the given directory.
 pub fn discover(info: &Info) -> Vec<(PathBuf, Egg)> {
@@ -63,22 +82,11 @@ pub fn discover(info: &Info) -> Vec<(PathBuf, Egg)> {
             }
 
             // try to get plugin configuration
-            match get_plugin_config(&path) {
+            match get_plugin_config(&path, info) {
                 Ok(mut config) => {
                     debug!("successfully loaded plugin config for {}: {:?}", filename, config.name);
 
-                    // inject env variables from host kurv environment
-                    // so that plugins can know where the kurv api is running, where logs are
-                    // stored, etc.
-                    let mut env = config.env.unwrap_or_default();
-                    env.insert("KURV_API_HOST".to_string(), info.api_host.clone());
-                    env.insert("KURV_API_PORT".to_string(), info.api_port.to_string());
-                    env.insert("KURV_HOME".to_string(), info.paths.kurv_home.display().to_string());
-                    env.insert(
-                        "KURV_LOGS_DIR".to_string(),
-                        info.paths.logs_dir.display().to_string(),
-                    );
-                    config.env = Some(env);
+                    config.env = Some(merge_injected_plugin_env(config.env.take(), info));
 
                     Some((path, config))
                 }
@@ -97,11 +105,12 @@ pub fn discover(info: &Info) -> Vec<(PathBuf, Egg)> {
 /// get plugin configuration
 ///
 /// executes a plugin with `--kurv-cfg` flag, to get its config; parses the JSON output as `Egg`.
-fn get_plugin_config(plugin_path: &Path) -> Result<Egg> {
+fn get_plugin_config(plugin_path: &Path, info: &Info) -> Result<Egg> {
     debug!("getting config for plugin: {}", plugin_path.display());
 
     let output = Command::new(plugin_path)
         .arg("--kurv-cfg")
+        .envs(injected_plugin_env(info))
         .output()
         .with_context(|| format!("failed to execute plugin: {}", plugin_path.display()))?;
 

--- a/app/kurv/tests/unit/mod.rs
+++ b/app/kurv/tests/unit/mod.rs
@@ -1,5 +1,6 @@
 // Unit tests for kurv
 mod egg_test;
+mod plugin_test;
 mod state_test;
 mod tcp_test;
 mod theme_test;

--- a/app/kurv/tests/unit/plugin_test.rs
+++ b/app/kurv/tests/unit/plugin_test.rs
@@ -1,0 +1,181 @@
+use {
+    kurv::kurv::Kurv,
+    std::{
+        env,
+        ffi::OsString,
+        fs,
+        path::Path,
+        sync::{Mutex, OnceLock},
+    },
+    tempfile::TempDir,
+};
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[test]
+fn test_collect_injects_kurv_env_into_cfg_and_runtime_env() {
+    let _lock = env_lock().lock().unwrap();
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().join("kurv-home");
+    let plugins_dir = home_dir.join("plugins");
+    let logs_dir = temp_dir.path().join("logs-dir");
+
+    fs::create_dir_all(&plugins_dir).unwrap();
+    create_plugin_executable(&plugins_dir, cfg_probe_script());
+
+    let _env = EnvGuard::set([
+        ("KURV_HOME", path_env(&home_dir)),
+        ("KURV_LOGS_DIR", path_env(&logs_dir)),
+        ("KURV_API_HOST", "127.9.9.9".into()),
+        ("KURV_API_PORT", "42424".into()),
+    ]);
+
+    let (_, state) = Kurv::collect().unwrap();
+    let state = state.lock().unwrap();
+    let plugins = state.get_plugins();
+
+    assert_eq!(plugins.len(), 1);
+
+    let env = plugins[0].env.as_ref().unwrap();
+    assert_eq!(env.get("SEEN_API_HOST"), Some(&"127.9.9.9".to_string()));
+    assert_eq!(env.get("SEEN_API_PORT"), Some(&"42424".to_string()));
+    assert_eq!(env.get("SEEN_KURV_HOME"), Some(&path_env(&home_dir)));
+    assert_eq!(env.get("SEEN_KURV_LOGS_DIR"), Some(&path_env(&logs_dir)));
+    assert_eq!(env.get("KURV_API_HOST"), Some(&"127.9.9.9".to_string()));
+    assert_eq!(env.get("KURV_API_PORT"), Some(&"42424".to_string()));
+    assert_eq!(env.get("KURV_HOME"), Some(&path_env(&home_dir)));
+    assert_eq!(env.get("KURV_LOGS_DIR"), Some(&path_env(&logs_dir)));
+}
+
+#[test]
+fn test_collect_prefers_injected_kurv_env_over_plugin_values() {
+    let _lock = env_lock().lock().unwrap();
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().join("kurv-home");
+    let plugins_dir = home_dir.join("plugins");
+    let logs_dir = temp_dir.path().join("logs-dir");
+
+    fs::create_dir_all(&plugins_dir).unwrap();
+    create_plugin_executable(&plugins_dir, stale_env_script());
+
+    let _env = EnvGuard::set([
+        ("KURV_HOME", path_env(&home_dir)),
+        ("KURV_LOGS_DIR", path_env(&logs_dir)),
+        ("KURV_API_HOST", "127.9.9.9".into()),
+        ("KURV_API_PORT", "42424".into()),
+    ]);
+
+    let (_, state) = Kurv::collect().unwrap();
+    let state = state.lock().unwrap();
+    let plugins = state.get_plugins();
+
+    assert_eq!(plugins.len(), 1);
+
+    let env = plugins[0].env.as_ref().unwrap();
+    assert_eq!(env.get("KURV_API_HOST"), Some(&"127.9.9.9".to_string()));
+    assert_eq!(env.get("KURV_API_PORT"), Some(&"42424".to_string()));
+    assert_eq!(env.get("KURV_HOME"), Some(&path_env(&home_dir)));
+    assert_eq!(env.get("KURV_LOGS_DIR"), Some(&path_env(&logs_dir)));
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn path_env(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
+struct EnvGuard {
+    previous: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvGuard {
+    fn set<const N: usize>(vars: [(&'static str, String); N]) -> Self {
+        let previous = vars.iter().map(|(key, _)| (*key, env::var_os(key))).collect::<Vec<_>>();
+
+        for (key, value) in vars {
+            unsafe {
+                env::set_var(key, value);
+            }
+        }
+
+        Self { previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.previous {
+            match value {
+                Some(value) => unsafe {
+                    env::set_var(key, value);
+                },
+                None => unsafe {
+                    env::remove_var(key);
+                },
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+fn create_plugin_executable(plugins_dir: &Path, script: &str) {
+    let script_path = plugins_dir.join("kurv-test.cmd");
+    fs::write(script_path, script).unwrap();
+}
+
+#[cfg(unix)]
+fn create_plugin_executable(plugins_dir: &Path, script: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script_path = plugins_dir.join("kurv-test");
+    fs::write(&script_path, script).unwrap();
+    let mut permissions = fs::metadata(&script_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(script_path, permissions).unwrap();
+}
+
+#[cfg(windows)]
+fn cfg_probe_script() -> &'static str {
+    r#"@echo off
+if "%1"=="--kurv-cfg" (
+  echo {"name":"kurv-test","command":"echo","env":{"SEEN_API_HOST":"%KURV_API_HOST%","SEEN_API_PORT":"%KURV_API_PORT%","SEEN_KURV_HOME":"%KURV_HOME%","SEEN_KURV_LOGS_DIR":"%KURV_LOGS_DIR%"}}
+  exit /b 0
+)
+exit /b 1
+"#
+}
+
+#[cfg(unix)]
+fn cfg_probe_script() -> &'static str {
+    r#"#!/bin/sh
+if [ "$1" = "--kurv-cfg" ]; then
+  printf '%s\n' '{"name":"kurv-test","command":"echo","env":{"SEEN_API_HOST":"'"$KURV_API_HOST"'","SEEN_API_PORT":"'"$KURV_API_PORT"'","SEEN_KURV_HOME":"'"$KURV_HOME"'","SEEN_KURV_LOGS_DIR":"'"$KURV_LOGS_DIR"'"}}'
+  exit 0
+fi
+exit 1
+"#
+}
+
+#[cfg(windows)]
+fn stale_env_script() -> &'static str {
+    r#"@echo off
+if "%1"=="--kurv-cfg" (
+  echo {"name":"kurv-test","command":"echo","env":{"KURV_API_HOST":"stale-host","KURV_API_PORT":"1111","KURV_HOME":"stale-home","KURV_LOGS_DIR":"stale-logs"}}
+  exit /b 0
+)
+exit /b 1
+"#
+}
+
+#[cfg(unix)]
+fn stale_env_script() -> &'static str {
+    r#"#!/bin/sh
+if [ "$1" = "--kurv-cfg" ]; then
+  printf '%s\n' '{"name":"kurv-test","command":"echo","env":{"KURV_API_HOST":"stale-host","KURV_API_PORT":"1111","KURV_HOME":"stale-home","KURV_LOGS_DIR":"stale-logs"}}'
+  exit 0
+fi
+exit 1
+"#
+}

--- a/crates/kurv-plugin-sdk/Cargo.toml
+++ b/crates/kurv-plugin-sdk/Cargo.toml
@@ -11,3 +11,6 @@ publish = false
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/crates/kurv-plugin-sdk/src/lib.rs
+++ b/crates/kurv-plugin-sdk/src/lib.rs
@@ -90,11 +90,11 @@ struct SidecarConfig {
 pub fn discover_env(exe: &Path) -> io::Result<BTreeMap<String, String>> {
     let config_path = sidecar_config_path(exe);
 
-    if !config_path.exists() {
-        return Ok(BTreeMap::new());
-    }
-
-    let content = fs::read_to_string(&config_path)?;
+    let content = match fs::read_to_string(&config_path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(err) => return Err(err),
+    };
     let config = serde_json::from_str::<SidecarConfig>(&content).map_err(|err| {
         io::Error::new(
             io::ErrorKind::InvalidData,

--- a/crates/kurv-plugin-sdk/src/lib.rs
+++ b/crates/kurv-plugin-sdk/src/lib.rs
@@ -3,15 +3,22 @@
 //! a plugin binary's `main` typically delegates everything to [`start`]:
 //!
 //! ```no_run
-//! use kurv_plugin_sdk::{KurvEnv, PluginConfig, start};
+//! use kurv_plugin_sdk::{KurvEnv, PluginConfig, discover_env, plugin_metadata, start};
 //!
 //! fn main() {
 //!     start(
-//!         |exe| PluginConfig {
-//!             name: "my-plugin".into(),
-//!             command: exe.to_string_lossy().into_owned(),
-//!             args: vec!["run".into()],
-//!             ..Default::default()
+//!         plugin_metadata!(),
+//!         |exe| {
+//!             let mut env = discover_env(exe).expect("kurv plugin: failed to load sidecar config");
+//!             env.insert("MY_PLUGIN_MODE".into(), "dev".into());
+//!
+//!             PluginConfig {
+//!                 name: "my-plugin".into(),
+//!                 command: exe.to_string_lossy().into_owned(),
+//!                 args: vec!["run".into()],
+//!                 env,
+//!                 ..Default::default()
+//!             }
 //!         },
 //!         |_env: KurvEnv| {
 //!             // plugin loop
@@ -21,14 +28,36 @@
 //! ```
 
 use {
-    serde::Serialize,
+    serde::{Deserialize, Serialize},
     std::{
         collections::BTreeMap,
-        env,
+        env, fmt, fs, io,
         path::{Path, PathBuf},
         process,
     },
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PluginMetadata {
+    pub name: &'static str,
+    pub version: &'static str,
+}
+
+impl fmt::Display for PluginMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.name, self.version)
+    }
+}
+
+#[macro_export]
+macro_rules! plugin_metadata {
+    () => {
+        $crate::PluginMetadata {
+            name: env!("CARGO_PKG_NAME"),
+            version: env!("CARGO_PKG_VERSION"),
+        }
+    };
+}
 
 /// subset of the kurv `Egg` struct that a plugin is allowed to declare via
 /// `--kurv-cfg`. the server fills in state / id / plugin flags on its side.
@@ -45,6 +74,41 @@ pub struct PluginConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct SidecarConfig {
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+}
+
+/// discovers an optional `{plugin-name}.config.json` file next to the plugin executable and
+/// returns the declared environment variables.
+///
+/// missing config files are treated as empty configuration. invalid JSON returns an
+/// `InvalidData` I/O error so plugins can fail fast with a clear message during `configure`.
+pub fn discover_env(exe: &Path) -> io::Result<BTreeMap<String, String>> {
+    let config_path = sidecar_config_path(exe);
+
+    if !config_path.exists() {
+        return Ok(BTreeMap::new());
+    }
+
+    let content = fs::read_to_string(&config_path)?;
+    let config = serde_json::from_str::<SidecarConfig>(&content).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to parse plugin sidecar config {}: {}", config_path.display(), err),
+        )
+    })?;
+
+    Ok(config.env)
+}
+
+fn sidecar_config_path(exe: &Path) -> PathBuf {
+    let plugin_name = exe.file_stem().and_then(|stem| stem.to_str()).unwrap_or("plugin");
+    let parent = exe.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!("{plugin_name}.config.json"))
 }
 
 /// environment variables kurv injects into every plugin process at spawn time.
@@ -69,9 +133,10 @@ impl KurvEnv {
 
 /// plugin entrypoint. parses `argv`, then:
 ///  - `--kurv-cfg`  → calls `configure(&exe)`, prints JSON to stdout, exits 0
+///  - `--version|-v` → prints `{plugin-name}@{plugin-version}`, exits 0
 ///  - `run`         → calls `run_loop(KurvEnv)`, exits 0 on return
 ///  - anything else → prints usage to stderr, exits 1
-pub fn start<C, R>(configure: C, run_loop: R) -> !
+pub fn start<C, R>(metadata: PluginMetadata, configure: C, run_loop: R) -> !
 where
     C: FnOnce(&Path) -> PluginConfig,
     R: FnOnce(KurvEnv),
@@ -85,12 +150,16 @@ where
             println!("{}", serde_json::to_string(&cfg).expect("kurv plugin: cfg not serializable"));
             process::exit(0);
         }
+        Some("--version") | Some("-v") => {
+            println!("{}", metadata);
+            process::exit(0);
+        }
         Some("run") => {
             run_loop(KurvEnv::from_env());
             process::exit(0);
         }
         _ => {
-            eprintln!("usage: {} [--kurv-cfg|run]", program_name());
+            eprintln!("usage: {} [--kurv-cfg|--version|-v|run]", program_name());
             process::exit(1);
         }
     }

--- a/crates/kurv-plugin-sdk/tests/discover_env_test.rs
+++ b/crates/kurv-plugin-sdk/tests/discover_env_test.rs
@@ -1,0 +1,48 @@
+use {
+    kurv_plugin_sdk::discover_env,
+    std::{fs, io::ErrorKind},
+    tempfile::TempDir,
+};
+
+#[test]
+fn test_discover_env_reads_sidecar_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let exe_path = temp_dir.path().join(executable_name());
+    let config_path = temp_dir.path().join("kurv-ui.config.json");
+
+    fs::write(&config_path, "{\"env\":{\"MY_ENV_VAR\":\"FOO-BAR\"}}").unwrap();
+
+    let env = discover_env(&exe_path).unwrap();
+    assert_eq!(env.get("MY_ENV_VAR"), Some(&"FOO-BAR".to_string()));
+}
+
+#[test]
+fn test_discover_env_returns_empty_when_sidecar_is_missing() {
+    let temp_dir = TempDir::new().unwrap();
+    let exe_path = temp_dir.path().join(executable_name());
+
+    let env = discover_env(&exe_path).unwrap();
+    assert!(env.is_empty());
+}
+
+#[test]
+fn test_discover_env_returns_invalid_data_error_for_bad_json() {
+    let temp_dir = TempDir::new().unwrap();
+    let exe_path = temp_dir.path().join(executable_name());
+    let config_path = temp_dir.path().join("kurv-ui.config.json");
+
+    fs::write(&config_path, "{\"env\":").unwrap();
+
+    let err = discover_env(&exe_path).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidData);
+}
+
+#[cfg(windows)]
+fn executable_name() -> &'static str {
+    "kurv-ui.exe"
+}
+
+#[cfg(not(windows))]
+fn executable_name() -> &'static str {
+    "kurv-ui"
+}

--- a/crates/kurv-plugin-sdk/tests/version_test.rs
+++ b/crates/kurv-plugin-sdk/tests/version_test.rs
@@ -1,0 +1,19 @@
+use kurv_plugin_sdk::{PluginMetadata, plugin_metadata};
+
+#[test]
+fn test_plugin_metadata_macro_uses_call_site_package_metadata() {
+    let metadata = plugin_metadata!();
+
+    assert_eq!(metadata.name, env!("CARGO_PKG_NAME"));
+    assert_eq!(metadata.version, env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn test_plugin_metadata_display_matches_expected_format() {
+    let metadata = PluginMetadata {
+        name: "kurv-ui",
+        version: "0.1.2",
+    };
+
+    assert_eq!(metadata.to_string(), "kurv-ui@0.1.2");
+}

--- a/plugins/kurv-ui/Cargo.toml
+++ b/plugins/kurv-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurv-ui"
-version = "0.0.0"
+version = "0.0.1"
 description = "kurv UI plugin (placeholder)"
 edition.workspace = true
 authors.workspace = true

--- a/plugins/kurv-ui/src/main.rs
+++ b/plugins/kurv-ui/src/main.rs
@@ -1,16 +1,22 @@
 use {
-    kurv_plugin_sdk::{KurvEnv, PluginConfig, start},
+    kurv_plugin_sdk::{KurvEnv, PluginConfig, discover_env, plugin_metadata, start},
     std::{env, thread, time::Duration},
 };
 
 fn main() {
     start(
-        |exe| PluginConfig {
-            name: "kurv-ui".into(),
-            command: exe.to_string_lossy().into_owned(),
-            args: vec!["run".into()],
-            env: [("HELLO_MESSAGE".into(), "Hello from kurv-ui plugin!".into())].into(),
-            ..Default::default()
+        plugin_metadata!(),
+        |exe| {
+            let mut env = discover_env(exe).expect("kurv-ui: failed to load sidecar config");
+            env.insert("HELLO_MESSAGE".into(), "Hello from kurv-ui plugin!".into());
+
+            PluginConfig {
+                name: "kurv-ui".into(),
+                command: exe.to_string_lossy().into_owned(),
+                args: vec!["run".into()],
+                env,
+                ..Default::default()
+            }
         },
         run,
     );


### PR DESCRIPTION
## Summary

This PR improves the plugin bootstrap flow by making Kurv inject runtime environment variables during `--kurv-cfg` discovery, and by extending the plugin SDK with opt-in sidecar config discovery and plugin version reporting.

## What Changed

- Inject `KURV_API_HOST`, `KURV_API_PORT`, `KURV_HOME`, and `KURV_LOGS_DIR` when Kurv probes plugins with `--kurv-cfg`.
- Reuse the same Kurv-side env source for both config discovery and the final runtime env injected into plugin processes.
- Add `discover_env` to `kurv-plugin-sdk` so plugins can load `{plugin-name}.config.json` from the executable directory.
- Keep sidecar config loading optional: missing files return empty config, while invalid JSON fails clearly.
- Add `--version` and `-v` handling to the SDK entrypoint, printing `{plugin-name}@{plugin-version}`.
- Capture plugin package metadata at the plugin crate call site via `plugin_metadata!()`, so version output reflects the plugin crate rather than the SDK crate.
- Update the `kurv-ui` example plugin to use sidecar env discovery and SDK-provided version metadata.

## Tests

- Added Kurv-side tests covering env injection during plugin discovery and precedence over plugin-provided values.
- Added SDK tests covering sidecar env discovery, invalid JSON handling, and plugin metadata/version formatting.
- Verified the example plugin builds and reports its version correctly.

## Validation

- `task check`
- `cargo test -p kurv --test unit_tests`
- `cargo test -p kurv-plugin-sdk`
- `cargo test -p kurv-ui`
- `cargo run -q -p kurv-ui -- --version`

---

Closes #38